### PR TITLE
大佬，发现您的项目引入了org.apache.shiro:shiro-core@1.3.2组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.hqyj</groupId>
@@ -104,7 +105,7 @@ https://mvnrepository.com/artifact/commons-fileupload/commons-fileupload
  <dependency>
      <groupId>org.apache.shiro</groupId>
      <artifactId>shiro-core</artifactId>
-     <version>1.3.2</version>
+     <version>1.8.0</version>
  </dependency>
  
  <dependency>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Apache Shiro 授权问题漏洞
缺陷组件：org.apache.shiro:shiro-core@1.3.2
漏洞编号：CVE-2021-41303
漏洞描述：Apache Shiro是美国阿帕奇（Apache）基金会的一套用于执行认证、授权、加密和会话管理的Java安全框架。
Apache Shiro 存在授权问题漏洞，该漏洞源于Apache Shiro在1.8.0版本之前，当使用Apache Shiro与Spring Boot时，一个特别制作的HTTP请求可能会导致身份验证绕过。
影响范围：(∞, 1.8.0)
最小修复版本：1.8.0
缺陷组件引入路径：com.hqyj:Space@0.0.1-SNAPSHOT->org.apache.shiro:shiro-core@1.3.2
```
另外我运行这个项目时，IDE的安全插件提示还有69个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p78993